### PR TITLE
Pass material theme LocalSaveable

### DIFF
--- a/shared-elements/src/main/java/com/mxalbert/sharedelements/CompositionLocalValuesSaver.kt
+++ b/shared-elements/src/main/java/com/mxalbert/sharedelements/CompositionLocalValuesSaver.kt
@@ -2,10 +2,13 @@ package com.mxalbert.sharedelements
 
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
+import androidx.compose.material.Colors
 import androidx.compose.material.LocalAbsoluteElevation
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Shapes
 import androidx.compose.runtime.*
 
 @Suppress("UNCHECKED_CAST")
@@ -18,19 +21,27 @@ private val compositionLocalList = listOf(
     LocalTextStyle
 ) as List<ProvidableCompositionLocal<Any>>
 
-@JvmInline
 @Immutable
-internal value class CompositionLocalValues(private val values: Array<ProvidedValue<*>>) {
+internal class CompositionLocalValues(
+    private val values: Array<ProvidedValue<*>>,
+    private val colors: Colors,
+    private val typography: androidx.compose.material.Typography,
+    private val shapes: Shapes
+) {
 
     @Composable
     @NonRestartableComposable
     fun Provider(content: @Composable () -> Unit) {
-        CompositionLocalProvider(*values, content = content)
+        CompositionLocalProvider(*values) {
+            MaterialTheme(colors, typography, shapes, content)
+        }
     }
-
 }
 
 internal val compositionLocalValues: CompositionLocalValues
     @Composable get() = CompositionLocalValues(
-        compositionLocalList.map { it provides it.current }.toTypedArray()
+        compositionLocalList.map { it provides it.current }.toTypedArray(),
+        MaterialTheme.colors,
+        MaterialTheme.typography,
+        MaterialTheme.shapes
     )


### PR DESCRIPTION
If shared element has a different theme, it would look differently while transitioning.

This PR also passes colors, typography and shapes to the root composable.